### PR TITLE
`SubclassSelector` is now support a concrete base class.

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
@@ -64,7 +64,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor {
 				
 				Type baseType = ManagedReferenceUtility.GetType(managedReferenceFieldTypename);
 				var popup = new AdvancedTypePopup(
-					TypeCache.GetTypesDerivedFrom(baseType).Where(p =>
+					TypeCache.GetTypesDerivedFrom(baseType).Append(baseType).Where(p =>
 						(p.IsPublic || p.IsNestedPublic) &&
 						!p.IsAbstract &&
 						!p.IsGenericType &&


### PR DESCRIPTION
## Description

<!--
Write a brief description of what you what to do with this PR.
-->

`SubclassSelector` is now support a concrete base class.

## Changes made

<!--
Itemize the changes.
-->

- When finding valid types, it now include it own type as a search target.