### PR TITLE
Force nesting when there is any sub menu in AddTypeMenu attribute.

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/AdvancedTypePopup.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/AdvancedTypePopup.cs
@@ -44,6 +44,11 @@ namespace MackySoft.SerializeReferenceExtensions.Editor {
 				if (splittedTypePath.Length <= 1) {
 					continue;
 				}
+				// If they explicitly want sub category, let them do.
+				if (TypeMenuUtility.GetAttribute(type) != null) {
+					isSingleNamespace = false;
+					break;
+				}
 				for (int k = 0;(splittedTypePath.Length - 1) > k;k++) {
 					string ns = namespaces[k];
 					if (ns == null) {
@@ -53,6 +58,10 @@ namespace MackySoft.SerializeReferenceExtensions.Editor {
 						isSingleNamespace = false;
 						break;
 					}
+				}
+
+				if (!isSingleNamespace) {
+					break;
 				}
 			}
 


### PR DESCRIPTION
## Description

<!--
Write a brief description of what you what to do with this PR.
-->

This fixes https://github.com/mackysoft/Unity-SerializeReferenceExtensions/issues/21.
Rather than just fix the bug, I considered '/' in menu name is explicit sub category.



## Changes made

<!--
Itemize the changes.
-->

- If there is any sub category(by /) in `TypeMenuAttribute`, disable `isSingleNamespace` flag.