### PR TITLE
Use menu name or type name as tie breaker.

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeMenuUtility.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeMenuUtility.cs
@@ -32,6 +32,11 @@ namespace MackySoft.SerializeReferenceExtensions.Editor {
 					return -999;
 				}
 				return GetAttribute(type)?.Order ?? 0;
+			}).ThenBy(type => {
+				if (type == null) {
+					return null;
+				}
+				return GetAttribute(type)?.MenuName ?? type.Name;
 			});
 		}
 


### PR DESCRIPTION
## Description

<!--
Write a brief description of what you what to do with this PR.
-->
I think even if there is no explicit order from attribute,
ordering items by using menu name (or type name) is better behaviour than some random order from `GetTypes`.


## Changes made

<!--
Itemize the changes.
-->

- Add `ThenBy` menu or type name after `OrderBy` order so they work as tie breaker.