### PR TITLE
Fix label overlapping button

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
@@ -35,19 +35,14 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 			EditorGUI.BeginProperty(position,label,property);
 
 			if (property.propertyType == SerializedPropertyType.ManagedReference) {
-				
+
 				// render label first to avoid label overlap for lists
 				Rect foldoutLabelRect = new Rect(position);
 				foldoutLabelRect.height = EditorGUIUtility.singleLineHeight;
 				foldoutLabelRect.x += EditorGUI.indentLevel * 12;
-				EditorGUI.PrefixLabel(foldoutLabelRect, label);
-				
-				// Draw the subclass selector popup.
-				Rect popupPosition = new Rect(position);
-				popupPosition.width -= EditorGUIUtility.labelWidth;
-				popupPosition.x += EditorGUIUtility.labelWidth;
-				popupPosition.height = EditorGUIUtility.singleLineHeight;
+				Rect popupPosition = EditorGUI.PrefixLabel(foldoutLabelRect, label);
 
+				// Draw the subclass selector popup.
 				if (EditorGUI.DropdownButton(popupPosition,GetTypeName(property),FocusType.Keyboard)) {
 					TypePopupCache popup = GetTypePopup(property);
 					m_TargetProperty = property;
@@ -62,7 +57,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 					Rect foldoutRect = new Rect(position);
 					foldoutRect.height = EditorGUIUtility.singleLineHeight;
 					property.isExpanded = EditorGUI.Foldout(foldoutRect, property.isExpanded, GUIContent.none, true);
-					
+
 					if (property.isExpanded)
 					{
 						using (new EditorGUI.IndentLevelScope())
@@ -102,7 +97,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
 			if (!m_TypePopups.TryGetValue(managedReferenceFieldTypename,out TypePopupCache result)) {
 				var state = new AdvancedDropdownState();
-				
+
 				Type baseType = ManagedReferenceUtility.GetType(managedReferenceFieldTypename);
 				var popup = new AdvancedTypePopup(
 					TypeCache.GetTypesDerivedFrom(baseType).Append(baseType).Where(p =>
@@ -125,7 +120,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
 						object obj = individualProperty.SetManagedReference(type);
 						individualProperty.isExpanded = (obj != null);
-						
+
 						individualObject.ApplyModifiedProperties();
 						individualObject.Update();
 					}

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
@@ -35,6 +35,13 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 			EditorGUI.BeginProperty(position,label,property);
 
 			if (property.propertyType == SerializedPropertyType.ManagedReference) {
+				
+				// render label first to avoid label overlap for lists
+				Rect foldoutLabelRect = new Rect(position);
+				foldoutLabelRect.height = EditorGUIUtility.singleLineHeight;
+				foldoutLabelRect.x += EditorGUI.indentLevel * 12;
+				EditorGUI.PrefixLabel(foldoutLabelRect, label);
+				
 				// Draw the subclass selector popup.
 				Rect popupPosition = new Rect(position);
 				popupPosition.width -= EditorGUIUtility.labelWidth;
@@ -54,7 +61,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 					// Draw the property with custom property drawer.
 					Rect foldoutRect = new Rect(position);
 					foldoutRect.height = EditorGUIUtility.singleLineHeight;
-					property.isExpanded = EditorGUI.Foldout(foldoutRect, property.isExpanded, label, true);
+					property.isExpanded = EditorGUI.Foldout(foldoutRect, property.isExpanded, GUIContent.none, true);
 					
 					if (property.isExpanded)
 					{
@@ -70,7 +77,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 				}
 				else
 				{
-					EditorGUI.PropertyField(position, property, label, true);
+					EditorGUI.PropertyField(position, property, GUIContent.none, true);
 				}
 			} else {
 				EditorGUI.LabelField(position,label,k_IsNotManagedReferenceLabel);


### PR DESCRIPTION
## Description

Currently the label overlaps the button, if the label is very long, or the inspector very thin. The width is correctly calculated for the button, but somehow not applied in the list rendering (there seems to be a minsize for the button, but I didn't find the code that would enforce that). By drawing the label first, the button will render over the label if there is an overlap. This seems to be a bug with list renderings. 

### Before

https://github.com/mackysoft/Unity-SerializeReferenceExtensions/assets/4518980/81d0b664-fbb5-4cb4-80d0-d2104471fadc

### After

https://github.com/mackysoft/Unity-SerializeReferenceExtensions/assets/4518980/f4640ec4-5bb5-4a53-8f20-9f6a42b3631a




## Changes made

* Draw label first
* Draw foldout without any label