### PR TITLE
Use TypeCache instead of manual type iteration

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/PropertyDrawerCache.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/PropertyDrawerCache.cs
@@ -26,49 +26,47 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 		static Type GetCustomPropertyDrawerType (Type type)
 		{
 			Type[] interfaceTypes = type.GetInterfaces();
-			
-			foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+
+			var types = TypeCache.GetTypesWithAttribute<CustomPropertyDrawer>();
+			foreach (Type drawerType in types)
 			{
-				foreach (Type drawerType in assembly.GetTypes())
+				var customPropertyDrawerAttributes = drawerType.GetCustomAttributes(typeof(CustomPropertyDrawer), true);
+				foreach (CustomPropertyDrawer customPropertyDrawer in customPropertyDrawerAttributes)
 				{
-					var customPropertyDrawerAttributes = drawerType.GetCustomAttributes(typeof(CustomPropertyDrawer), true);
-					foreach (CustomPropertyDrawer customPropertyDrawer in customPropertyDrawerAttributes)
+					var field = customPropertyDrawer.GetType().GetField("m_Type", BindingFlags.NonPublic | BindingFlags.Instance);
+					if (field != null)
 					{
-						var field = customPropertyDrawer.GetType().GetField("m_Type", BindingFlags.NonPublic | BindingFlags.Instance);
-						if (field != null)
+						var fieldType = field.GetValue(customPropertyDrawer) as Type;
+						if (fieldType != null)
 						{
-							var fieldType = field.GetValue(customPropertyDrawer) as Type;
-							if (fieldType != null)
+							if (fieldType == type)
 							{
-								if (fieldType == type)
+								return drawerType;
+							}
+							
+							// If the property drawer also allows for being applied to child classes, check if they match
+							var useForChildrenField = customPropertyDrawer.GetType().GetField("m_UseForChildren", BindingFlags.NonPublic | BindingFlags.Instance);
+							if (useForChildrenField != null)
+							{
+								object useForChildrenValue = useForChildrenField.GetValue(customPropertyDrawer);
+								if (useForChildrenValue is bool && (bool)useForChildrenValue)
 								{
-									return drawerType;
-								}
-								
-								// If the property drawer also allows for being applied to child classes, check if they match
-								var useForChildrenField = customPropertyDrawer.GetType().GetField("m_UseForChildren", BindingFlags.NonPublic | BindingFlags.Instance);
-								if (useForChildrenField != null)
-								{
-									object useForChildrenValue = useForChildrenField.GetValue(customPropertyDrawer);
-									if (useForChildrenValue is bool && (bool)useForChildrenValue)
+									// Check interfaces
+									if (Array.Exists(interfaceTypes, interfaceType => interfaceType == fieldType))
 									{
-										// Check interfaces
-										if (Array.Exists(interfaceTypes, interfaceType => interfaceType == fieldType))
+										return drawerType;
+									}
+
+									// Check derived types
+									Type baseType = type.BaseType;
+									while (baseType != null)
+									{
+										if (baseType == fieldType)
 										{
 											return drawerType;
 										}
 
-										// Check derived types
-										Type baseType = type.BaseType;
-										while (baseType != null)
-										{
-											if (baseType == fieldType)
-											{
-												return drawerType;
-											}
-
-											baseType = baseType.BaseType;
-										}
+										baseType = baseType.BaseType;
 									}
 								}
 							}


### PR DESCRIPTION
fix/use-type-cache

## Description

<!--
Write a brief description of what you what to do with this PR.
-->

The PropertyDrawerType cache generation had a performance bottleneck, which could be resolved by using Unity's [TypeCache](https://docs.unity3d.com/ScriptReference/TypeCache.html).

Performance before:

1. Selecting Item A
![image](https://github.com/mackysoft/Unity-SerializeReferenceExtensions/assets/141171189/8148ed71-1bf8-45fe-8dac-d8a5af7b2ef9)
2. Selecting Item B
![image](https://github.com/mackysoft/Unity-SerializeReferenceExtensions/assets/141171189/9c277b66-5aa3-48a0-b433-7a1edb0e9030)


Performance after:

1. Selecting Item A
![image](https://github.com/mackysoft/Unity-SerializeReferenceExtensions/assets/141171189/370ca086-b533-4904-99ce-851304498e62)
2. Selecting Item B
![image](https://github.com/mackysoft/Unity-SerializeReferenceExtensions/assets/141171189/246b203c-5779-4dde-ab35-69127a30cd58)


## Changes made

<!--
Itemize the changes.
-->

- Converted PropertyDrawerCache type detection to use TypeCache