### PR TITLE
fix: foldout arrow rendered out of the inspector in 2022.3 and newer

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
@@ -57,7 +57,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 					Rect foldoutRect = new Rect(position);
 					foldoutRect.height = EditorGUIUtility.singleLineHeight;
 
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_2022_2
 					// NOTE: Position x must be adjusted.
 					// FIXME: Is there a more essential solution...?
 					foldoutRect.x -= 12;


### PR DESCRIPTION
## Description

As mentioned in #66, hardcoded foldout position adjustment in [SubclassSelectorDrawer, lines 60 to 64](https://github.com/mackysoft/Unity-SerializeReferenceExtensions/blob/b7d76fb0c5133adc87e09c1d7aea87882a1d812a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs#L60) for `UNITY_2022_2_OR_NEVER` is redundant for newer versions (2022.3 and forwards) so I replaced the ifdef with `UNITY_2022_2` and that's it.