### PR TITLE
Support for serializing generic classes has been implemented.

### DIFF
--- a/Assets/Example/Example_Generics.cs
+++ b/Assets/Example/Example_Generics.cs
@@ -83,6 +83,32 @@ public sealed class NetworkActorAction3 : IContravarianceAction<IActor>, ICovari
     public IActor Actor => null;
 }
 
+namespace TestExample.Generics
+{
+    public interface IObjectHolder<T>
+    {
+        T Value { get; }
+    }
+
+    [Serializable]
+    public sealed class ObjectHolder<T> : IObjectHolder<T>
+    {
+        [SerializeField]
+        private T value;
+
+        public T Value => value;
+    }
+
+    [Serializable]
+    public sealed class ParticleSystemHolder : IObjectHolder<ParticleSystem>
+    {
+        [SerializeField]
+        private ParticleSystem value;
+
+        public ParticleSystem Value => value;
+    }
+}
+
 public class Example_Generics : MonoBehaviour
 {
 
@@ -97,5 +123,11 @@ public class Example_Generics : MonoBehaviour
 
     [SerializeReference, SubclassSelector]
     public List<ICovarianceAction<INetworkActor>> covarianceActions = new List<ICovarianceAction<INetworkActor>>();
+
+    [SerializeReference, SubclassSelector]
+    public TestExample.Generics.IObjectHolder<GameObject> gameObjectHolder = null;
+
+    [SerializeReference, SubclassSelector]
+    public TestExample.Generics.IObjectHolder<ParticleSystem> particleSystemHolder = null;
 
 }

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeMenuUtility.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeMenuUtility.cs
@@ -24,10 +24,14 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             }
             else
             {
-                int splitIndex = type.FullName.LastIndexOf('.');
+                // In the case of Generic, type information is included as shown below, so it must be extracted.
+                // TestNamespace.TestClass`1[[UnityEngine.GameObject, UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null]]
+                var name = type.IsGenericType ? type.FullName.Substring(0, type.FullName.IndexOf("[")) : type.FullName;
+
+                int splitIndex = name.LastIndexOf('.');
                 if (splitIndex >= 0)
                 {
-                    return new string[] { type.FullName.Substring(0, splitIndex), type.FullName.Substring(splitIndex + 1) };
+                    return new string[] { name.Substring(0, splitIndex), name.Substring(splitIndex + 1) };
                 }
                 else
                 {

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/IIntrinsicTypePolicy.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/IIntrinsicTypePolicy.cs
@@ -4,6 +4,6 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 {
     public interface IIntrinsicTypePolicy
     {
-        bool IsAllowed (Type candiateType);
+        bool IsAllowed (Type candiateType, bool ignoreGenericTypeCheck);
     }
 }

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/IntrinsicTypePolicy/DefaultIntrinsicTypePolicy.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/IntrinsicTypePolicy/DefaultIntrinsicTypePolicy.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine;
 
 namespace MackySoft.SerializeReferenceExtensions.Editor
 {
@@ -7,12 +8,12 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
         public static readonly DefaultIntrinsicTypePolicy Instance = new DefaultIntrinsicTypePolicy();
 
-        public bool IsAllowed (Type candiateType)
+        public bool IsAllowed (Type candiateType, bool ignoreGenericTypeCheck)
         {
             return
                 (candiateType.IsPublic || candiateType.IsNestedPublic || candiateType.IsNestedPrivate) &&
                 !candiateType.IsAbstract &&
-                !candiateType.IsGenericType &&
+                (ignoreGenericTypeCheck || !candiateType.IsGenericType) &&
                 !candiateType.IsPrimitive &&
                 !candiateType.IsEnum &&
                 !typeof(UnityEngine.Object).IsAssignableFrom(candiateType) &&

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateProvider/DefaultTypeCandiateProvider.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateProvider/DefaultTypeCandiateProvider.cs
@@ -21,7 +21,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
         {
             return TypeCache.GetTypesDerivedFrom(baseType)
                 .Append(baseType)
-                .Where(intrinsicTypePolicy.IsAllowed);
+                .Where(x => intrinsicTypePolicy.IsAllowed(x, false));
         }
     }
 }

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateProvider/Unity_2023_2_OrNewer_TypeCandiateProvider.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateProvider/Unity_2023_2_OrNewer_TypeCandiateProvider.cs
@@ -47,15 +47,14 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
             result = new List<Type>();
 
-            // 
-            var isGenericBaseType = baseType.IsGenericType;
-            var genericTypeDefinition = isGenericBaseType ? baseType.GetGenericTypeDefinition() : baseType;
-            var targetTypeArguments = isGenericBaseType ? baseType.GetGenericArguments() : Type.EmptyTypes;
+            bool isGenericBaseType = baseType.IsGenericType;
+            Type genericTypeDefinition = isGenericBaseType ? baseType.GetGenericTypeDefinition() : baseType;
+            Type[] targetTypeArguments = isGenericBaseType ? baseType.GetGenericArguments() : Type.EmptyTypes;
             IEnumerable<Type> types = TypeCache.GetTypesDerivedFrom(genericTypeDefinition);
             foreach (Type type in types)
             {
                 // If the type is Generic, create a MakeGenericType from the Arguments of the baseType.
-                var targetType = type.IsGenericType ? type.MakeGenericType(targetTypeArguments) : type;
+                Type targetType = type.IsGenericType ? type.MakeGenericType(targetTypeArguments) : type;
 
                 if (!intrinsicTypePolicy.IsAllowed(targetType, targetType != type))
                 {

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateService.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateService.cs
@@ -8,16 +8,12 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
     {
 
         private readonly ITypeCandiateProvider typeCandiateProvider;
-        private readonly IIntrinsicTypePolicy intrinsicTypePolicy;
-        private readonly ITypeCompatibilityPolicy typeCompatibilityPolicy;
 
         private readonly Dictionary<Type, Type[]> typeCache = new Dictionary<Type, Type[]>();
 
-        public TypeCandiateService (ITypeCandiateProvider typeCandiateProvider, IIntrinsicTypePolicy intrinsicTypePolicy, ITypeCompatibilityPolicy typeCompatibilityPolicy)
+        public TypeCandiateService (ITypeCandiateProvider typeCandiateProvider)
         {
             this.typeCandiateProvider = typeCandiateProvider ?? throw new ArgumentNullException(nameof(typeCandiateProvider));
-            this.intrinsicTypePolicy = intrinsicTypePolicy ?? throw new ArgumentNullException(nameof(intrinsicTypePolicy));
-            this.typeCompatibilityPolicy = typeCompatibilityPolicy ?? throw new ArgumentNullException(nameof(typeCompatibilityPolicy));
         }
 
         public IReadOnlyList<Type> GetDisplayableTypes (Type baseType)
@@ -33,8 +29,6 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
             var candiateTypes = typeCandiateProvider.GetTypeCandidates(baseType);
             var result = candiateTypes
-                .Where(intrinsicTypePolicy.IsAllowed)
-                .Where(t => typeCompatibilityPolicy.IsCompatible(baseType, t))
                 .Distinct()
                 .ToArray();
 

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeSearchService.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeSearchService.cs
@@ -3,24 +3,18 @@
     public static class TypeSearchService
     {
 
-        public static readonly IIntrinsicTypePolicy IntrinsicTypePolicy;
-        public static readonly ITypeCompatibilityPolicy TypeCompatibilityPolicy;
         public static readonly ITypeCandiateProvider TypeCandiateProvider;
         public static readonly TypeCandiateService TypeCandiateService;
 
         static TypeSearchService ()
         {
-            IntrinsicTypePolicy = DefaultIntrinsicTypePolicy.Instance;
-
 #if UNITY_2023_2_OR_NEWER
-            TypeCompatibilityPolicy = Unity_2023_2_OrNewer_GenericVarianceTypeCompatibilityPolicy.Instance;
             TypeCandiateProvider = Unity_2023_2_OrNewer_TypeCandiateProvider.Instance;
 #else
-            TypeCompatibilityPolicy = DefaultTypeCompatibilityPolicy.Instance;
             TypeCandiateProvider = DefaultTypeCandiateProvider.Instance;
 #endif
 
-            TypeCandiateService = new TypeCandiateService(TypeCandiateProvider, IntrinsicTypePolicy, TypeCompatibilityPolicy);
+            TypeCandiateService = new TypeCandiateService(TypeCandiateProvider);
         }
     }
 }

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Tests/Editor/DefaultIntrinsicTypePolicyTests.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Tests/Editor/DefaultIntrinsicTypePolicyTests.cs
@@ -26,7 +26,7 @@ namespace MackySoft.SerializeReferenceExtensions.Tests
         [TestCaseSource(nameof(Cases))]
         public void IsAllowed_MatchesExpected (Type type, bool expected)
         {
-            bool actual = DefaultIntrinsicTypePolicy.Instance.IsAllowed(type);
+            bool actual = DefaultIntrinsicTypePolicy.Instance.IsAllowed(type, false);
             Assert.That(actual, Is.EqualTo(expected), type.FullName);
         }
     }

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Tests/Editor/TypeCandidateService_GenericVarianceTests.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Tests/Editor/TypeCandidateService_GenericVarianceTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using MackySoft.SerializeReferenceExtensions.Editor;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace MackySoft.SerializeReferenceExtensions.Tests
 {
@@ -38,6 +39,33 @@ namespace MackySoft.SerializeReferenceExtensions.Tests
 
             Assert.That(set, Does.Contain(typeof(Invariant_Actor)));
             Assert.That(set, !Does.Contain(typeof(Invariant_NetworkActor)));
+        }
+
+        [Test]
+        public void GenericClass_ParticleSystem_IsSupported ()
+        {
+            var set = TypeSearchService.TypeCandiateService.GetDisplayableTypes(typeof(IObjectHolder<ParticleSystem>)).ToHashSet();
+
+            Assert.That(set, Does.Contain(typeof(ObjectHolder<ParticleSystem>)));
+            Assert.That(set, Does.Contain(typeof(ParticleSystemHolder)));
+        }
+
+        [Test]
+        public void GenericClass_GameObject_IsSupported ()
+        {
+            var set = TypeSearchService.TypeCandiateService.GetDisplayableTypes(typeof(IObjectHolder<GameObject>)).ToHashSet();
+
+            Assert.That(set, Does.Contain(typeof(ObjectHolder<GameObject>)));
+            Assert.That(set, !Does.Contain(typeof(ParticleSystemHolder)));
+        }
+
+        [Test]
+        public void GenericClass_Integer_IsSupported ()
+        {
+            var set = TypeSearchService.TypeCandiateService.GetDisplayableTypes(typeof(IObjectHolder<int>)).ToHashSet();
+
+            Assert.That(set, Does.Contain(typeof(ObjectHolder<int>)));
+            Assert.That(set, !Does.Contain(typeof(ParticleSystemHolder)));
         }
     }
 }

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Tests/Editor/TypeCandidateTestTypes.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Tests/Editor/TypeCandidateTestTypes.cs
@@ -61,6 +61,8 @@ namespace MackySoft.SerializeReferenceExtensions.Tests
     public interface ICovariant<out T> { T Create (); }
     public interface IInvariant<T> { }
 
+    public interface IObjectHolder<T> { }
+
     [Serializable]
     public sealed class Contravariant_Actor : IContravariant<IActor> { }
 
@@ -93,4 +95,10 @@ namespace MackySoft.SerializeReferenceExtensions.Tests
 
     [Serializable]
     public sealed class Invariant_NetworkActor : IInvariant<INetworkActor> { }
+
+    [Serializable]
+    public sealed class ObjectHolder<T> : IObjectHolder<T> { }
+
+    [Serializable]
+    public sealed class ParticleSystemHolder : IObjectHolder<ParticleSystem> { }
 }


### PR DESCRIPTION
## Description

<!--
Write a brief description of what you what to do with this PR.
-->

![レコーディング 2026-01-22 151951](https://github.com/user-attachments/assets/6e0cb32a-72e8-4f26-92e1-c51e604ab757)

Support for generic classes such as the following has been added:

```csharp
public interface IObjectHolder<T> { }

[Serializable]
public sealed class ObjectHolder<T> : IObjectHolder<T> { }

[Serializable]
public sealed class ParticleSystemHolder : IObjectHolder<ParticleSystem> { }

public sealed class Test : MonoBehaviour
{
    // The following items are listed in the dropdown menu:
    // - ObjectHolder
    [SerializeReference, SubclassSelector]
    private IObjectHolder<GameObject> gameObjectHolder;

    // The following items are listed in the dropdown menu:
    // - ObjectHolder
    // - ParticleSystemHolder
    [SerializeReference, SubclassSelector]
    private IObjectHolder<ParticleSystem> particleSystemHolder;
}
```

## Changes made

<!--
Itemize the changes.
-->

- When searching for a target type that is a GenericType, we now use the `MakeGenericType` function to generate the type.
- Added `ignoreGenericTypeCheck` to `IntrinsicTypePolicy.IsAllowed`, enabling the option to bypass evaluation of `IsGenericType` .
  - This flag is set to true only when `MakeGenericType` is called.
- When the Type was a generic type, the dropdown menu did not display correctly, so I fixed `TypeMenuUtility.GetSplittedTypePath` .
- `TypeCandidateService` no longer performs checks based on `IIntrinsicTypePolicy` and `ITypeCompatibilityPolicy` .
  - Because `ITypeCandidateProvider` already performs this check, we determined this processing is unnecessary.

