### PR TITLE
Fix UseToStringAsLabel on SubclassSelector attribute

### DIFF
--- a/Assets/Example/Example.cs
+++ b/Assets/Example/Example.cs
@@ -9,6 +9,8 @@ public abstract class Food
     public string name;
 
     public float kcal;
+
+    public override string ToString () => $"{name} ({kcal} kcal)";
 }
 
 [Serializable]
@@ -84,6 +86,15 @@ public class Example : MonoBehaviour
 
     [SerializeReference, SubclassSelector]
     public List<Food> foodsTwo = new List<Food>
+    {
+        new Apple(),
+        new Peach(),
+        new Grape()
+    };
+    
+    // UseToStringAsLabel support on UNITY_2021_3_OR_NEWER
+    [SerializeReference, SubclassSelector(UseToStringAsLabel = true)]
+    public List<Food> foodsThree = new List<Food>
     {
         new Apple(),
         new Peach(),

--- a/Assets/Example/Example.unity
+++ b/Assets/Example/Example.unity
@@ -260,9 +260,28 @@ MonoBehaviour:
   - rid: 9020349853700980772
   - rid: 9020349853700980773
   - rid: 9020349853700980774
+  foodsThree:
+  - rid: 7418200600248058228
+  - rid: 7418200600248058229
+  - rid: 7418200600248058230
   references:
     version: 2
     RefIds:
+    - rid: 7418200600248058228
+      type: {class: Apple, ns: , asm: Assembly-CSharp}
+      data:
+        name: Apple
+        kcal: 100
+    - rid: 7418200600248058229
+      type: {class: Peach, ns: , asm: Assembly-CSharp}
+      data:
+        name: Peach
+        kcal: 100
+    - rid: 7418200600248058230
+      type: {class: Grape, ns: , asm: Assembly-CSharp}
+      data:
+        name: Grape
+        kcal: 100
     - rid: 9020349853700980763
       type: {class: Apple, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/SubclassSelectorDrawer.cs
@@ -35,20 +35,12 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
         public override void OnGUI (Rect position, SerializedProperty property, GUIContent label)
         {
-            EditorGUI.BeginProperty(position, label, property);
 
             if (property.propertyType == SerializedPropertyType.ManagedReference)
             {
-                // Render label first to avoid label overlap for lists
-                Rect foldoutLabelRect = new Rect(position);
-                foldoutLabelRect.height = EditorGUIUtility.singleLineHeight;
-
-                // NOTE: IndentedRect should be disabled as it causes extra indentation.
-                //foldoutLabelRect = EditorGUI.IndentedRect(foldoutLabelRect);
-                Rect popupPosition = EditorGUI.PrefixLabel(foldoutLabelRect, label);
-
 #if UNITY_2021_3_OR_NEWER
                 // Override the label text with the ToString() of the managed reference.
+                // Must be called before EditorGUI.BeginProperty
                 var subclassSelectorAttribute = (SubclassSelectorAttribute)attribute;
                 if (subclassSelectorAttribute.UseToStringAsLabel && !property.hasMultipleDifferentValues)
                 {
@@ -59,6 +51,15 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
                     }
                 }
 #endif
+                
+                EditorGUI.BeginProperty(position, label, property);
+                // Render label first to avoid label overlap for lists
+                Rect foldoutLabelRect = new Rect(position);
+                foldoutLabelRect.height = EditorGUIUtility.singleLineHeight;
+
+                // NOTE: IndentedRect should be disabled as it causes extra indentation.
+                //foldoutLabelRect = EditorGUI.IndentedRect(foldoutLabelRect);
+                Rect popupPosition = EditorGUI.PrefixLabel(foldoutLabelRect, label);
 
                 // Draw the subclass selector popup.
                 if (EditorGUI.DropdownButton(popupPosition, GetTypeName(property), FocusType.Keyboard))
@@ -129,6 +130,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             }
             else
             {
+                EditorGUI.BeginProperty(position, label, property);
                 EditorGUI.LabelField(position, label, IsNotManagedReferenceLabel);
             }
 


### PR DESCRIPTION
## Description
I am using unity editor version 6000.3.7f1.
The property `UseToStringAsLabel` on the `SubclassSelector` attribute does not currently appear to have any impact on the GUI render.

According to this code on the current main branch, we would expect the `foodThree` example field to be rendered in the editor with label "Grape".
https://github.com/mackysoft/Unity-SerializeReferenceExtensions/blob/e23441ee587cd1f4727cf417b85433c77462b53a/Assets/Example/Example.cs#L73-L75
However the left side of the screenshot below shows that is not the case - the name remains as "Food Three".


## Changes made
- Moved `EditorGUI.BeginProperty` calls after the `label.text` override.
- Added `ToString` override in Food example class
- Added list `Foods Three` to Example script with `UseToStringAsLabel = true`

## Screenshots
Left is before the fix, Right is after the fix
<img width="2117" height="1694" alt="image" src="https://github.com/user-attachments/assets/1db71eae-6a38-4574-8781-2538e3914b82" />

Thanks.