### PR TITLE
Checks and fixes for pasting copied reference fields

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/ManagedReferenceContextualPropertyMenu.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/ManagedReferenceContextualPropertyMenu.cs
@@ -11,10 +11,20 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
         private const string CopiedPropertyPathKey = "SerializeReferenceExtensions.CopiedPropertyPath";
         private const string ClipboardKey = "SerializeReferenceExtensions.CopyAndPasteProperty";
+        private const string CopiedPropertyType = "SerializeReferenceExtensions.CopiedPropertyType";
 
         private static readonly GUIContent PasteContent = new GUIContent("Paste Property");
         private static readonly GUIContent NewInstanceContent = new GUIContent("New Instance");
         private static readonly GUIContent ResetAndNewInstanceContent = new GUIContent("Reset and New Instance");
+        
+        private enum ValuePasteState
+        {
+            Unavailable, // No copied value in clipboard
+            Allowed, // No issues detected
+            WillChangeType, // Pasting will overwrite type currently assigned to property
+            IncompatibleType, // The copied type isn't compatible with the target property
+            TypeNotFound // The copied data referenced a type that cannot be found or is invalid
+        }
 
         [InitializeOnLoadMethod]
         private static void Initialize ()
@@ -22,6 +32,50 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             EditorApplication.contextualPropertyMenu += OnContextualPropertyMenu;
         }
 
+        private static ValuePasteState GetValuePasteState (SerializedProperty property)
+        {
+            string copiedPropertyPath = SessionState.GetString(CopiedPropertyPathKey, string.Empty);
+            
+            if (string.IsNullOrEmpty(copiedPropertyPath))
+            {
+                return ValuePasteState.Unavailable;
+            }
+
+            string copiedValueTypeName = SessionState.GetString(CopiedPropertyType, string.Empty);
+            Type copiedValueType = Type.GetType(copiedValueTypeName);
+
+            if (copiedValueType == null)
+            {
+                return ValuePasteState.TypeNotFound;
+            }
+            
+            object currentPropertyValue = property.managedReferenceValue;
+
+            if (currentPropertyValue == null)
+            {
+                return IsValidTypeFor(property, copiedValueType)
+                    ? ValuePasteState.Allowed
+                    : ValuePasteState.IncompatibleType;
+            }
+            
+            if (copiedValueType == currentPropertyValue.GetType())
+            {
+                return ValuePasteState.Allowed;
+            }
+
+            return IsValidTypeFor(property, copiedValueType)
+                ? ValuePasteState.WillChangeType
+                : ValuePasteState.IncompatibleType;
+        }
+
+        private static bool IsValidTypeFor (SerializedProperty property, Type candidateType)
+        {
+            Type baseType = ManagedReferenceUtility.GetType(property.managedReferenceFieldTypename);
+            if (baseType == null || candidateType == null) return false;
+
+            return TypeSearchService.TypeCandiateService.IsCandidateQualified(baseType, candidateType);
+        }
+        
         private static void OnContextualPropertyMenu (GenericMenu menu, SerializedProperty property)
         {
             if (property.propertyType == SerializedPropertyType.ManagedReference)
@@ -32,14 +86,36 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
                 menu.AddItem(new GUIContent($"Copy \"{property.propertyPath}\" property"), false, Copy, clonedProperty);
 
+                string typeName = SessionState.GetString(CopiedPropertyType, string.Empty);
+                
                 string copiedPropertyPath = SessionState.GetString(CopiedPropertyPathKey, string.Empty);
-                if (!string.IsNullOrEmpty(copiedPropertyPath))
+
+                Type targetType = Type.GetType(typeName);
+                
+                switch (GetValuePasteState(clonedProperty))
                 {
-                    menu.AddItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property"), false, Paste, clonedProperty);
-                }
-                else
-                {
-                    menu.AddDisabledItem(PasteContent);
+                    case ValuePasteState.Allowed:
+                        menu.AddItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property"), false, Paste, clonedProperty);
+                        break;
+                    case ValuePasteState.WillChangeType:
+                        menu.AddItem(
+                            new GUIContent(
+                                $"Paste \"{copiedPropertyPath}\" property (⚠️ Will overwrite type with {targetType?.Name})"
+                            ),
+                            false,
+                            Paste,
+                            clonedProperty
+                        );
+                        break;
+                    case ValuePasteState.IncompatibleType:
+                        menu.AddDisabledItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property (❌ Incompatible type {targetType?.FullName})"));
+                        break;
+                    case ValuePasteState.TypeNotFound:
+                        menu.AddDisabledItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property (❌ Invalid type)"));
+                        break;
+                    default:
+                        menu.AddDisabledItem(PasteContent);
+                        break;
                 }
 
                 menu.AddSeparator("");
@@ -64,19 +140,49 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             string json = JsonUtility.ToJson(property.managedReferenceValue);
             SessionState.SetString(CopiedPropertyPathKey, property.propertyPath);
             SessionState.SetString(ClipboardKey, json);
+            if (property.managedReferenceValue == null)
+            {
+                SessionState.SetString(CopiedPropertyType, string.Empty);
+            }
+            else
+            {
+                string typeName = property.managedReferenceValue.GetType().AssemblyQualifiedName;
+                SessionState.SetString(CopiedPropertyType, typeName);
+            }
         }
 
         private static void Paste (object customData)
         {
             SerializedProperty property = (SerializedProperty)customData;
             string json = SessionState.GetString(ClipboardKey, string.Empty);
-            if (string.IsNullOrEmpty(json))
+            string typeName = SessionState.GetString(CopiedPropertyType, string.Empty);
+            
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(typeName))
             {
                 return;
             }
-
             Undo.RecordObject(property.serializedObject.targetObject, "Paste Property");
-            JsonUtility.FromJsonOverwrite(json, property.managedReferenceValue);
+
+            Type targetType = Type.GetType(typeName);
+
+            if (targetType == null)
+            {
+                Debug.LogError($"Paste Failed: Could not find type {typeName}");
+                return;
+            }
+            
+            object currentTargetValue = property.managedReferenceValue;
+            
+            if (currentTargetValue == null || targetType != currentTargetValue.GetType())
+            {
+                object newInstance = Activator.CreateInstance(targetType);
+                JsonUtility.FromJsonOverwrite(json, newInstance);
+                property.managedReferenceValue = newInstance;
+            }
+            else
+            {
+                JsonUtility.FromJsonOverwrite(json, property.managedReferenceValue);
+            }
             property.serializedObject.ApplyModifiedProperties();
         }
 

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/ManagedReferenceContextualPropertyMenu.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/ManagedReferenceContextualPropertyMenu.cs
@@ -24,7 +24,9 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             WillChangeType, // Pasting will overwrite type currently assigned to property
             IncompatibleType, // The copied type isn't compatible with the target property
             TypeNotFound, // The copied data referenced a type that cannot be found or is invalid
-            WillNullify // The copied value is null, will nullify/delete the property value
+            WillNullify, // The copied value is null, will nullify/delete the property value
+            TargetNullAllowed, // The target property is null, but otherwise compatible
+            TargetNullIncompatible // The target property is null and copied type is incompatible
         }
 
         [InitializeOnLoadMethod]
@@ -59,8 +61,8 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             if (currentPropertyValue == null)
             {
                 return IsValidTypeFor(property, copiedValueType)
-                    ? ValuePasteState.Allowed
-                    : ValuePasteState.IncompatibleType;
+                    ? ValuePasteState.TargetNullAllowed
+                    : ValuePasteState.TargetNullIncompatible;
             }
             
             if (copiedValueType == currentPropertyValue.GetType())
@@ -96,30 +98,40 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
                 string copiedPropertyPath = SessionState.GetString(CopiedPropertyPathKey, string.Empty);
 
                 Type targetType = Type.GetType(typeName);
+
+                string pasteLabel = $"Paste \"{copiedPropertyPath}\" property";
                 
                 switch (GetValuePasteState(clonedProperty))
                 {
                     case ValuePasteState.Allowed:
-                        menu.AddItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property"), false, Paste, clonedProperty);
+                        menu.AddItem(
+                            new GUIContent(pasteLabel), false, PasteValues, clonedProperty);
                         break;
                     case ValuePasteState.WillChangeType: 
                         menu.AddItem(
-                            new GUIContent(
-                                $"Paste \"{copiedPropertyPath}\" property (⚠️ Will overwrite type with {targetType?.Name})"
-                            ),
+                            new GUIContent($"{pasteLabel}/Paste Type and Values (⚠️ Change type to {targetType?.Name})"),
                             false,
-                            Paste,
+                            PasteTypeAndValues,
                             clonedProperty
                         );
+                        menu.AddItem(new GUIContent($"{pasteLabel}/Paste Values Only"), false, PasteValues, clonedProperty);
                         break;
                     case ValuePasteState.WillNullify:
-                        menu.AddItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property (⚠️ Will set to null)"), false, Paste, clonedProperty);
+                        menu.AddItem(new GUIContent($"{pasteLabel} (⚠️ Set to null)"), false, PasteTypeAndValues, clonedProperty);
                         break;
                     case ValuePasteState.IncompatibleType:
-                        menu.AddDisabledItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property (❌ Incompatible type {targetType?.FullName})"));
+                        menu.AddDisabledItem(new GUIContent($"{pasteLabel}/Paste Type and Values (❌ Incompatible type {targetType?.FullName})"));
+                        menu.AddItem(new GUIContent($"{pasteLabel}/Paste Values Only"), false, PasteValues, clonedProperty);
                         break;
                     case ValuePasteState.TypeNotFound:
-                        menu.AddDisabledItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property (❌ Invalid type)"));
+                        menu.AddDisabledItem(new GUIContent($"{pasteLabel}/Paste Type and Values (❌ Invalid type)"));
+                        menu.AddItem(new GUIContent($"{pasteLabel}/Paste Values Only"), false, PasteValues, clonedProperty);
+                        break;
+                    case ValuePasteState.TargetNullAllowed:
+                        menu.AddItem(new GUIContent($"Create New and Paste \"{copiedPropertyPath}\" property"), false, PasteTypeAndValues, clonedProperty);
+                        break;
+                    case ValuePasteState.TargetNullIncompatible:
+                        menu.AddDisabledItem(new GUIContent($"Create New and Paste (❌ Incompatible type {targetType?.FullName})"));
                         break;
                     default:
                         menu.AddDisabledItem(PasteContent);
@@ -159,7 +171,28 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             }
         }
 
-        private static void Paste (object customData)
+        private static void PasteValues (object customData)
+        {
+            SerializedProperty property = (SerializedProperty)customData;
+            string json = SessionState.GetString(ClipboardKey, string.Empty);
+            
+            if (string.IsNullOrEmpty(json))
+            {
+                return;
+            }
+            Undo.RecordObject(property.serializedObject.targetObject, "Paste Property");
+            
+            object currentTargetValue = property.managedReferenceValue;
+
+            if (currentTargetValue == null)
+            {
+                return;
+            }
+            JsonUtility.FromJsonOverwrite(json, property.managedReferenceValue);
+            property.serializedObject.ApplyModifiedProperties();
+        }
+
+        private static void PasteTypeAndValues (object customData)
         {
             SerializedProperty property = (SerializedProperty)customData;
             string json = SessionState.GetString(ClipboardKey, string.Empty);

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/ManagedReferenceContextualPropertyMenu.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/ManagedReferenceContextualPropertyMenu.cs
@@ -23,7 +23,8 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             Allowed, // No issues detected
             WillChangeType, // Pasting will overwrite type currently assigned to property
             IncompatibleType, // The copied type isn't compatible with the target property
-            TypeNotFound // The copied data referenced a type that cannot be found or is invalid
+            TypeNotFound, // The copied data referenced a type that cannot be found or is invalid
+            WillNullify // The copied value is null, will nullify/delete the property value
         }
 
         [InitializeOnLoadMethod]
@@ -44,12 +45,16 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
             string copiedValueTypeName = SessionState.GetString(CopiedPropertyType, string.Empty);
             Type copiedValueType = Type.GetType(copiedValueTypeName);
 
+            object currentPropertyValue = property.managedReferenceValue;
+            
             if (copiedValueType == null)
             {
-                return ValuePasteState.TypeNotFound;
+                if (!string.IsNullOrEmpty(copiedValueTypeName)) return ValuePasteState.TypeNotFound;
+                
+                return currentPropertyValue == null
+                    ? ValuePasteState.Unavailable
+                    : ValuePasteState.WillNullify;
             }
-            
-            object currentPropertyValue = property.managedReferenceValue;
 
             if (currentPropertyValue == null)
             {
@@ -71,8 +76,8 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
         private static bool IsValidTypeFor (SerializedProperty property, Type candidateType)
         {
             Type baseType = ManagedReferenceUtility.GetType(property.managedReferenceFieldTypename);
-            if (baseType == null || candidateType == null) return false;
-
+            if (baseType == null) return false;
+            
             return TypeSearchService.TypeCandiateService.IsCandidateQualified(baseType, candidateType);
         }
         
@@ -97,7 +102,7 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
                     case ValuePasteState.Allowed:
                         menu.AddItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property"), false, Paste, clonedProperty);
                         break;
-                    case ValuePasteState.WillChangeType:
+                    case ValuePasteState.WillChangeType: 
                         menu.AddItem(
                             new GUIContent(
                                 $"Paste \"{copiedPropertyPath}\" property (⚠️ Will overwrite type with {targetType?.Name})"
@@ -106,6 +111,9 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
                             Paste,
                             clonedProperty
                         );
+                        break;
+                    case ValuePasteState.WillNullify:
+                        menu.AddItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property (⚠️ Will set to null)"), false, Paste, clonedProperty);
                         break;
                     case ValuePasteState.IncompatibleType:
                         menu.AddDisabledItem(new GUIContent($"Paste \"{copiedPropertyPath}\" property (❌ Incompatible type {targetType?.FullName})"));
@@ -155,25 +163,32 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
         {
             SerializedProperty property = (SerializedProperty)customData;
             string json = SessionState.GetString(ClipboardKey, string.Empty);
-            string typeName = SessionState.GetString(CopiedPropertyType, string.Empty);
             
-            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(typeName))
+            string typeName = SessionState.GetString(CopiedPropertyType, string.Empty);
+            Type targetType = Type.GetType(typeName);
+            
+            if (string.IsNullOrEmpty(json) && targetType != null)
             {
                 return;
             }
             Undo.RecordObject(property.serializedObject.targetObject, "Paste Property");
-
-            Type targetType = Type.GetType(typeName);
-
-            if (targetType == null)
+            
+            // targetType can be null under two conditions:
+            // 1) The type was actually null (empty typeName)
+            // 2) The type was not found (non-empty typename)
+            if (targetType == null && !string.IsNullOrEmpty(typeName))
             {
                 Debug.LogError($"Paste Failed: Could not find type {typeName}");
                 return;
             }
             
             object currentTargetValue = property.managedReferenceValue;
-            
-            if (currentTargetValue == null || targetType != currentTargetValue.GetType())
+
+            if (targetType == null)
+            {
+                property.managedReferenceValue = null;
+            }
+            else if (currentTargetValue == null || targetType != currentTargetValue.GetType())
             {
                 object newInstance = Activator.CreateInstance(targetType);
                 JsonUtility.FromJsonOverwrite(json, newInstance);

--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateService.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/TypeSearch/TypeCandiateService.cs
@@ -33,13 +33,18 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
             var candiateTypes = typeCandiateProvider.GetTypeCandidates(baseType);
             var result = candiateTypes
-                .Where(intrinsicTypePolicy.IsAllowed)
-                .Where(t => typeCompatibilityPolicy.IsCompatible(baseType, t))
+                .Where(t => IsCandidateQualified(baseType, t))
                 .Distinct()
                 .ToArray();
 
             typeCache.Add(baseType, result);
             return result;
+        }
+
+        public bool IsCandidateQualified (Type baseType, Type candidateType)
+        {
+            return intrinsicTypePolicy.IsAllowed(candidateType)
+                && typeCompatibilityPolicy.IsCompatible(baseType, candidateType);
         }
     }
 }


### PR DESCRIPTION
## Description

When copying and pasting values from a property's context menu, there were currently no checks in place to avoid certain issues:
- Attempting to paste to a property who's current value is null causes an error due to `JsonUtility.FromJsonOverwrite`
- Pasting a value from one type into a field of a different type, which may or may not have the appropriate fields

Added logic to check for potential conflicts and handle them.


## Changes made

- Store the copied field type in `SessionState` for use in type safety comparisons
- Test for potential conflicts and return result as enum for handling
- Implement menu items for different results:
  - When no issues are detected or copied value is empty continue as before, with no change
  - When copied value is different type than current value, but still valid for the property, then pasting will create a new instance via Activator and then merge the JSON in. The Paste menu item shows a warning that the type will be overwritten.
  - When current value is null, create a new instance using Activator before using JSON overwrite to avoid error.
  - When copied value type is not valid for the field (uses `TypeCandiateService` [which is mis-spelled as a note, should be Candidate]) then disable the menu item with message explaining incompatible type.
  - When copied value refers to an invalid of non-existent type (type may be deleted between copy and paste) add disabled item with text stating invalid type
- Exposed function for evaluating qualification from `TypeCandiateService`, which evaluates the `intrinsicTypePolicy` and `typeCompatibilityPolicy`, for use in testing field combability in pasting, so that the `TypeCandiateService` is a single point of truth on this test.
