### PR TITLE
[FIX] AdvancedDropdownItem.children is obsolete in 6.5+

### DIFF
--- a/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/AdvancedTypePopup.cs
+++ b/Assets/MackySoft/MackySoft.SerializeReferenceExtensions/Editor/AdvancedTypePopup.cs
@@ -121,7 +121,11 @@ namespace MackySoft.SerializeReferenceExtensions.Editor
 
         private static AdvancedDropdownItem GetItem (AdvancedDropdownItem parent, string name)
         {
+#if UNITY_6000_5_OR_NEWER // AdvancedDropdownItem.children is obsolete in Unity 6.5+, use more optimized childList
+            foreach (AdvancedDropdownItem item in parent.childList)
+#else
             foreach (AdvancedDropdownItem item in parent.children)
+#endif
             {
                 if (item.name == name)
                 {


### PR DESCRIPTION
## Description

In Unity 6.5, `AdvancedDropdownItem.children` was made obsolete and replaced with `AdvancedDropdownItem.childList` which is made more optimized and returns a `ReadOnlyList` instead of an `IEnumerable`.

## Changes made

When `UNITY_6000_5_OR_NEWER` replaced usage with `childList` to resolve compilation error on 6.5